### PR TITLE
Fix import path in alimentiReducer tests

### DIFF
--- a/src/__tests__/alimentiReducer.test.js
+++ b/src/__tests__/alimentiReducer.test.js
@@ -1,4 +1,4 @@
-import { alimentiReducer } from "../utils/Transformations"; // ✅ named import
+import { alimentiReducer } from "../context/AlimentiContext"; // ✅ named import
 import { isValidAlimento } from "../utils/validations";
 
 describe("alimentiReducer", () => {


### PR DESCRIPTION
## Summary
- update `alimentiReducer.test.js` to import reducer from context

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6885d499cdd4832e9bc0aec5c5a41f60